### PR TITLE
refactor: InfaqTypeController to use ApiResponse

### DIFF
--- a/app/Http/Controllers/Api/InfaqTypeController.php
+++ b/app/Http/Controllers/Api/InfaqTypeController.php
@@ -2,13 +2,14 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Http\Requests\UpdateInfaqTypeRequest;
-use Illuminate\Http\Request;
+use App\Helpers\ApiResponse;
+use App\Services\InfaqTypeService;
 use App\Http\Controllers\Controller;
-use Illuminate\Support\Facades\Validator;
-use App\Repository\Services\InfaqTypeService;
-use Symfony\Component\HttpKernel\Exception\HttpException;
+use App\Http\Resources\InfaqTypeCollection;
 use App\Http\Requests\StoreInfaqTypeRequest;
+use App\Http\Requests\UpdateInfaqTypeRequest;
+use App\Http\Resources\InfaqTypeSimpleResource;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class InfaqTypeController extends Controller
 {
@@ -23,15 +24,11 @@ class InfaqTypeController extends Controller
      */
     public function index()
     {
-
-        try {
-            return $this->infaqTypeService->getAll(); 
-        } catch (HttpException $e) {
-            return response()->json([
-                'success' => false,
-                'message' => $e->getMessage(),
-            ], $e->getStatusCode());
-        }
+        return ApiResponse::success(
+            new InfaqTypeCollection($this->infaqTypeService->getAllInfaqTypes()),
+            "Berhasil mendapatkan data tipe infaq!",
+            200
+        );
     }
 
     /**
@@ -40,12 +37,18 @@ class InfaqTypeController extends Controller
     public function store(StoreInfaqTypeRequest $request)
     {
         try {
-            return $this->infaqTypeService->create($request->validated());
+            return ApiResponse::success([
+                "infaq_type" => new InfaqTypeSimpleResource($this->infaqTypeService->createInfaqType($request->validated()))
+            ],
+                "Berhasil menambahkan tipe infaq baru!",
+                201
+            );
         } catch (HttpException $e) {
-            return response()->json([
-                'success' => false,
-                'message' => $e->getMessage(),
-            ], $e->getStatusCode());
+            return ApiResponse::error(
+                "Gagal menambahkan tipe infaq baru!",
+                $e->getMessage(),
+                $e->getStatusCode()
+            );
         }
     }
 
@@ -55,12 +58,18 @@ class InfaqTypeController extends Controller
     public function show(string $id)
     {
         try {
-            return $this->infaqTypeService->getById($id);
+            return ApiResponse::success([
+                "infaq_type" => new InfaqTypeSimpleResource($this->infaqTypeService->getInfaqTypeById($id))
+            ],
+                "Tipe infaq yang dicari berhasil ditemukan!",
+                200
+            );
         } catch (HttpException $e) {
-            return response()->json([
-                'success' => false,
-                'message' => $e->getMessage(),
-            ], $e->getStatusCode());
+            return ApiResponse::error(
+                "Tipe infaq yang dicari tidak ditemukan!",
+                $e->getMessage(),
+                $e->getStatusCode()
+            );
         }
     }
 
@@ -70,12 +79,18 @@ class InfaqTypeController extends Controller
     public function update(UpdateInfaqTypeRequest $request, string $id)
     {
         try {
-            return $this->infaqTypeService->update($request->validated(), $id);
+            return ApiResponse::success([
+                "infaq_type" => new InfaqTypeSimpleResource($this->infaqTypeService->updateInfaqType($id, $request->validated()))
+            ],
+                "Berhasil mengubah tipe infaq!",
+                200
+            );
         } catch (HttpException $e) {
-            return response()->json([
-                'success' => false,
-                'message' => $e->getMessage(),
-            ], $e->getStatusCode());
+            return ApiResponse::error(
+                "Gagal mengubah tipe infaq!",
+                $e->getMessage(),
+                $e->getStatusCode()
+            );
         }
     }
 
@@ -85,12 +100,18 @@ class InfaqTypeController extends Controller
     public function destroy(string $id)
     {
         try {
-            return $this->infaqTypeService->delete($id);
+            return ApiResponse::success([
+                "infaq_type" => new InfaqTypeSimpleResource($this->infaqTypeService->deleteInfaqType($id))
+            ],
+                "Berhasil menghapus tipe infaq!",
+                200
+            );
         } catch (HttpException $e) {
-            return response()->json([
-                'success' => false,
-                'message' => $e->getMessage(),
-            ], $e->getStatusCode());
+            return ApiResponse::error(
+                "Gagal mengubah tipe infaq!",
+                $e->getMessage(),
+                $e->getStatusCode()
+            );
         }
     }
 }

--- a/app/Http/Requests/StoreInfaqTypeRequest.php
+++ b/app/Http/Requests/StoreInfaqTypeRequest.php
@@ -24,8 +24,8 @@ class StoreInfaqTypeRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ["required","string","unique:infaq_types,name","max:255"],
-            'description' =>["required","string"], 
+            'name' => ["required", "unique:infaq_types,name", "max:255"],
+            'description' =>["required"],
         ];
     }
     protected function failedValidation(Validator $validator)

--- a/app/Http/Requests/UpdateInfaqTypeRequest.php
+++ b/app/Http/Requests/UpdateInfaqTypeRequest.php
@@ -26,10 +26,10 @@ class UpdateInfaqTypeRequest extends FormRequest
     {
         return [
             'name' => [
-                "required","string","max:255",
-                Rule::unique("infaq_types", "name")->ignore(request()->route('infaq_type'))           
+                "required","max:255",
+                Rule::unique("infaq_types", "name")->ignore(request()->route('infaq_type'))
             ],
-            'description' => 'required|string',
+            'description' => ['required'],
         ];
     }
     protected function failedValidation(Validator $validator)

--- a/app/Http/Resources/InfaqTypeCollection.php
+++ b/app/Http/Resources/InfaqTypeCollection.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class InfaqTypeCollection extends ResourceCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @return array<int|string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            "infaq_types" => InfaqTypeSimpleResource::collection($this->collection),
+            "pagination" => [
+                "total" => $this->total(),
+                "per_page" => $this->perPage(),
+                "current_page" => $this->currentPage(),
+                "last_page" => $this->lastPage(),
+                "first_page_url" => $this->url(1),
+                "last_page_url" => $this->url($this->lastPage()),
+                "next_page_url" => $this->nextPageUrl(),
+                "prev_page_url" => $this->previousPageUrl(),
+                "path" => $this->path(),
+                "from" => $this->firstItem(),
+                "to" => $this->lastItem(),
+            ]
+        ];
+    }
+}

--- a/app/Http/Resources/InfaqTypeSimpleResource.php
+++ b/app/Http/Resources/InfaqTypeSimpleResource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class InfaqTypeSimpleResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            "id" => $this->id,
+            "infaq_type_code" => $this->infaq_type_code,
+            "name" => ucwords($this->name),
+            "description" => $this->description,
+            "created_at" => $this->created_at,
+            "created_at_human" => $this->created_at->diffforhumans()
+        ];
+    }
+}

--- a/app/Providers/RepositoryServiceProvider.php
+++ b/app/Providers/RepositoryServiceProvider.php
@@ -2,20 +2,20 @@
 
 namespace App\Providers;
 
+use App\Repositories\Contracts\InfaqTypeContract;
+use App\Repositories\Contracts\RoleContract;
+use App\Repositories\Contracts\UserContract;
+use App\Repositories\Eloquent\UserRepository;
+use App\Repositories\Eloquent\InfaqTypeRepository;
+use App\Repositories\Eloquent\RoleRepository;
 use Illuminate\Support\ServiceProvider;
 use App\Repository\Services\ItemService;
 use App\Repository\Services\NewsService;
 use App\Repository\Services\EventService;
-use App\Repositories\Contracts\RoleContract;
-use App\Repositories\Contracts\UserContract;
 use App\Repository\Interfaces\ItemInterface;
 use App\Repository\Interfaces\NewsInterface;
-use App\Repositories\Eloquent\RoleRepository;
-use App\Repositories\Eloquent\UserRepository;
 use App\Repository\Interfaces\EventInterface;
-use App\Repository\Services\InfaqTypeService;
 use App\Repository\Services\NewsCategoryService;
-use App\Repository\Interfaces\InfaqTypeInterface;
 use App\Repository\Services\EventScheduleService;
 use App\Repository\Interfaces\NewsCategoryInterface;
 use Illuminate\Contracts\Support\DeferrableProvider;
@@ -42,7 +42,7 @@ class RepositoryServiceProvider extends ServiceProvider implements DeferrablePro
         $this->app->bind(NewsInterface::class, NewsService::class);
         $this->app->bind(EventInterface::class, EventService::class);
         $this->app->bind(EventScheduleInterface::class, EventScheduleService::class);
-        $this->app->bind(InfaqTypeInterface::class, InfaqTypeService::class);
+        $this->app->bind(InfaqTypeContract::class, InfaqTypeRepository::class);
         $this->app->bind(IncomeInfaqTransactionInterface::class, IncomeInfaqTransactionService::class);
         $this->app->bind(ExpenseTransactionInterface::class, ExpenseTransactionService::class);
         $this->app->bind(ItemInterface::class, ItemService::class);
@@ -62,11 +62,11 @@ class RepositoryServiceProvider extends ServiceProvider implements DeferrablePro
         return [
             UserContract::class,
             RoleContract::class,
+            InfaqTypeContract::class,
             NewsCategoryInterface::class,
             NewsInterface::class,
             EventInterface::class,
             EventScheduleInterface::class,
-            InfaqTypeInterface::class,
             IncomeInfaqTransactionInterface::class,
             ExpenseTransactionInterface::class,
             ItemInterface::class,

--- a/app/Repositories/Contracts/InfaqTypeContract.php
+++ b/app/Repositories/Contracts/InfaqTypeContract.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Repositories\Contracts;
+
+interface InfaqTypeContract
+{
+    public function all();
+    public function findOrFail(string $id);
+    public function create(array $data);
+    public function update(string $id, array $data);
+    public function delete(string $id);
+}

--- a/app/Repositories/Eloquent/InfaqTypeRepository.php
+++ b/app/Repositories/Eloquent/InfaqTypeRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Repositories\Eloquent;
+use App\Models\InfaqType;
+use App\Repositories\Contracts\InfaqTypeContract;
+
+class InfaqTypeRepository Implements InfaqTypeContract
+{
+    protected $infaqType;
+
+    public function __construct(InfaqType $infaqType)
+    {
+        $this->infaqType = $infaqType;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function all() {
+        return $this->infaqType->select("id", "infaq_type_code", "name", "description", "created_at")->paginate(3);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function create(array $data) {
+        return $this->infaqType->create($data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function delete(string $id) {
+        return $this->infaqType->findOrFail($id)->deleteOrFail();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findOrFail(string $id) {
+        return $this->infaqType->select("id", "infaq_type_code", "name", "description", "created_at")->findOrFail($id);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function update(string $id, array $data) {
+        return $this->infaqType->findOrFail($id)->updateOrFail($data);
+    }
+}

--- a/app/Services/InfaqTypeService.php
+++ b/app/Services/InfaqTypeService.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\InfaqType;
+use App\Libraries\CodeGeneration;
+use App\Repositories\Contracts\InfaqTypeContract;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class InfaqTypeService
+{
+    protected CodeGeneration $infaqTypeCode;
+    public function __construct(protected InfaqTypeContract $infaqTypeRepository)
+    {
+        $this->infaqTypeRepository = $infaqTypeRepository;
+        $this->infaqTypeCode = new CodeGeneration(InfaqType::class, "infaq_type_code", "ITP");
+    }
+
+    public function getAllInfaqTypes() {
+        return $this->infaqTypeRepository->all();
+    }
+
+    public function getInfaqTypeById(string $id) {
+        try {
+            $user = $this->infaqTypeRepository->findOrFail($id);
+        } catch (\Exception $e) {
+            throw new HttpException(404, $e->getMessage());
+        }
+
+        return $user;
+    }
+
+    private function getInfaqTypeCode(): string {
+        return $this->infaqTypeCode->getGeneratedCode();
+    }
+
+    public function createInfaqType(array $data) {
+        return $this->infaqTypeRepository->create([
+            "infaq_type_code" => $this->getInfaqTypeCode(),
+            ...$data,
+        ]);
+    }
+
+    public function updateInfaqType(string $id, array $data) {
+        $infaqType = $this->getInfaqTypeById($id);
+
+        try {
+            return $this->infaqTypeRepository->update($id, $data) === true ? $infaqType : false;
+        } catch (\Exception $e) {
+            throw new HttpException(500, $e->getMessage());
+        }
+    }
+
+    public function deleteInfaqType(string $id) {
+        $infaqType = $this->getInfaqTypeById($id);
+
+        try {
+            return $this->infaqTypeRepository->delete($id) === true ? $infaqType : false;
+        } catch (\Exception $e) {
+            throw new HttpException(500, $e->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Improves the InfaqTypeController by implementing a standardized API response format using the ApiResponse helper. This change enhances consistency and readability of API responses for all controller actions (index, store, show, update, destroy). It also updates the controller to use the `InfaqTypeCollection` and `InfaqTypeSimpleResource` resources for formatting the output.

Also, updates RepositoryServiceProvider to bind InfaqTypeContract to InfaqTypeRepository.