### PR TITLE
refactor: fixes incorrect variable name and updates path

### DIFF
--- a/app/Http/Controllers/Api/FinanceExpenseController.php
+++ b/app/Http/Controllers/Api/FinanceExpenseController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Api;
 
 use App\Helpers\ApiResponse;
-use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\FinanceExpense\StoreFinanceExpenseRequest;
 use App\Http\Requests\FinanceExpense\UpdateFinanceExpenseRequest;

--- a/app/Services/FinanceExpenseService.php
+++ b/app/Services/FinanceExpenseService.php
@@ -19,12 +19,12 @@ class FinanceExpenseService
 
     public function getFinanceExpenseById(string $id) {
         try {
-            $financeIncome = $this->financeExpenseRepository->findOrFail($id);
+            $financeExpense = $this->financeExpenseRepository->findOrFail($id);
         } catch (\Exception $e) {
             throw new HttpException(404, $e->getMessage());
         }
 
-        return $financeIncome;
+        return $financeExpense;
     }
 
     public function createFinanceExpense(array $data) {
@@ -36,28 +36,28 @@ class FinanceExpenseService
     }
 
     public function updateFinanceExpense(string $id, array $data) {
-        $financeIncome = $this->getFinanceExpenseById($id);
+        $financeExpense = $this->getFinanceExpenseById($id);
 
         if(isset($data["transaction_receipt"]) && $data["transaction_receipt"] instanceof \Illuminate\Http\UploadedFile) {
-            if(!empty($financeIncome->transaction_receipt) && Storage::disk('public')->exists(path: $financeIncome->transaction_receipt)) {
-                Storage::disk('public')->delete($financeIncome->transaction_receipt);
+            if(!empty($financeExpense->transaction_receipt) && Storage::disk('public')->exists(path: $financeExpense->transaction_receipt)) {
+                Storage::disk('public')->delete($financeExpense->transaction_receipt);
             }
 
             $data["transaction_receipt"] = "storage/". $this->uploadFile($data["transaction_receipt"]);
         }
 
         try {
-            return $this->financeExpenseRepository->update($id, $data) === true ? $financeIncome->fresh() : false;
+            return $this->financeExpenseRepository->update($id, $data) === true ? $financeExpense->fresh() : false;
         } catch (\Exception $e) {
             throw new HttpException(500, $e->getMessage());
         }
     }
 
     public function deleteFinanceExpense(string $id) {
-        $financeIncome = $this->getFinanceExpenseById($id);
+        $financeExpense = $this->getFinanceExpenseById($id);
 
         try {
-            return $this->financeExpenseRepository->delete($id) === true ? $financeIncome : false;
+            return $this->financeExpenseRepository->delete($id) === true ? $financeExpense : false;
         } catch (\Exception $e) {
             throw new HttpException(500, $e->getMessage());
         }
@@ -66,6 +66,6 @@ class FinanceExpenseService
     public function uploadFile($transactionReceipt) {
         $receiptName = $transactionReceipt->hashName();
 
-        return $transactionReceipt->storePubliclyAs("income-expenses", $receiptName, "public");
+        return $transactionReceipt->storePubliclyAs("expense-receipt", $receiptName, "public");
     }
 }


### PR DESCRIPTION
Corrects a variable naming error where `$financeIncome` was used instead of `$financeExpense` in the FinanceExpenseService.

Updates the transaction receipt storage path from `income-expenses` to `expense-receipt` to better reflect the purpose of the uploaded files.