### PR TITLE
refactor: filters and orders income list

### DIFF
--- a/app/Repositories/Eloquent/FinanceIncomeRepository.php
+++ b/app/Repositories/Eloquent/FinanceIncomeRepository.php
@@ -20,8 +20,9 @@ class FinanceIncomeRepository Implements FinanceIncomeContract
         return $this->financeIncome->select(
             "id", "income_transaction", "date", "finance_category_id",
             "description", "amount", "transaction_receipt", "created_at"
-        )->with("financeCategory")
-        ->get();
+        )->whereHas("financeCategory", function($query) {
+            $query->where("type", "=", "income");
+        })->orderByDesc("id")->get();
     }
 
     /**
@@ -45,7 +46,9 @@ class FinanceIncomeRepository Implements FinanceIncomeContract
         return $this->financeIncome->select(
             "id", "income_transaction", "date", "finance_category_id",
             "description", "amount", "transaction_receipt", "created_at"
-        )->findOrFail($id);
+        )->whereHas("financeCategory", function($query) {
+            $query->where("type", "=", "income");
+        })->findOrFail($id);
     }
 
     /**

--- a/app/Services/FinanceIncomeService.php
+++ b/app/Services/FinanceIncomeService.php
@@ -39,8 +39,10 @@ class FinanceIncomeService
         $financeIncome = $this->getFinanceIncomeById($id);
 
         if(isset($data["transaction_receipt"]) && $data["transaction_receipt"] instanceof \Illuminate\Http\UploadedFile) {
-            if(!empty($financeIncome->transaction_receipt) && Storage::disk('public')->exists(path: $financeIncome->transaction_receipt)) {
-                Storage::disk('public')->delete($financeIncome->transaction_receipt);
+            $receiptPath = str_replace("storage/", "", $financeIncome->transaction_receipt);
+
+            if(!empty($financeIncome->transaction_receipt) && Storage::disk('public')->exists(path: $receiptPath)) {
+                Storage::disk('public')->delete($receiptPath);
             }
 
             $data["transaction_receipt"] = "storage/". $this->uploadFile($data["transaction_receipt"]);
@@ -57,6 +59,12 @@ class FinanceIncomeService
         $financeIncome = $this->getFinanceIncomeById($id);
 
         try {
+            $receiptPath = str_replace("storage/", "", $financeIncome->transaction_receipt);
+
+            if(!empty($financeIncome->transaction_receipt) && Storage::disk('public')->exists(path: $receiptPath)) {
+                Storage::disk('public')->delete($receiptPath);
+            }
+            
             return $this->financeIncomeRepository->delete($id) === true ? $financeIncome : false;
         } catch (\Exception $e) {
             throw new HttpException(500, $e->getMessage());


### PR DESCRIPTION
Ensures that only finance categories with the type "income" are displayed.

Also, sorts the income list by ID in descending order.

Additionally, corrects the file deletion logic in update and delete methods by removing the "storage/" prefix before deleting transaction receipts. This prevents deletion failures due to incorrect file paths.