### PR TITLE
refactor: refines income data retrieval and generation

### DIFF
--- a/app/Repositories/Eloquent/FinanceIncomeRepository.php
+++ b/app/Repositories/Eloquent/FinanceIncomeRepository.php
@@ -22,7 +22,7 @@ class FinanceIncomeRepository Implements FinanceIncomeContract
             "description", "amount", "transaction_receipt", "created_at"
         )->whereHas("financeCategory", function($query) {
             $query->where("type", "=", "income");
-        })->orderByDesc("id")->get();
+        })->latest()->get();
     }
 
     /**

--- a/database/factories/FinanceIncomeFactory.php
+++ b/database/factories/FinanceIncomeFactory.php
@@ -48,7 +48,7 @@ class FinanceIncomeFactory extends Factory
 
         return [
             "date" => $this->faker->date(),
-            "finance_category_id" => FinanceCategory::inRandomOrder()->value("id"),
+            "finance_category_id" => FinanceCategory::inRandomOrder()->where("type", "=", "income")->value("id"),
             "description" => $this->faker->sentence(10),
             "amount" => $this->faker->numberBetween(1000, 1000000),
             "transaction_receipt" => 'storage/income-receipts/' . basename($filePath),


### PR DESCRIPTION
Improves the way income data is retrieved and generated for better data consistency and efficiency.

- Updates the income retrieval query to use `latest()` for ordering, improving readability and potentially performance.
- Modifies the `FinanceIncomeFactory` to only select `finance_category_id` with type income, ensuring generated data is consistent with the intended income category.