### PR TITLE
refactor: update exception handling for income transactional

### DIFF
--- a/app/Services/FinanceIncomeService.php
+++ b/app/Services/FinanceIncomeService.php
@@ -36,19 +36,18 @@ class FinanceIncomeService
     }
 
     public function updateFinanceIncome(string $id, array $data) {
-        $financeIncome = $this->getFinanceIncomeById($id);
-
-        if(isset($data["transaction_receipt"]) && $data["transaction_receipt"] instanceof \Illuminate\Http\UploadedFile) {
-            $receiptPath = str_replace("storage/", "", $financeIncome->transaction_receipt);
-
-            if(!empty($financeIncome->transaction_receipt) && Storage::disk('public')->exists(path: $receiptPath)) {
-                Storage::disk('public')->delete($receiptPath);
-            }
-
-            $data["transaction_receipt"] = "storage/". $this->uploadFile($data["transaction_receipt"]);
-        }
-
         try {
+            $financeIncome = $this->getFinanceIncomeById($id);
+
+            if(isset($data["transaction_receipt"]) && $data["transaction_receipt"] instanceof \Illuminate\Http\UploadedFile) {
+                $receiptPath = str_replace("storage/", "", $financeIncome->transaction_receipt);
+
+                if(!empty($financeIncome->transaction_receipt) && Storage::disk('public')->exists(path: $receiptPath)) {
+                    Storage::disk('public')->delete($receiptPath);
+                }
+
+                $data["transaction_receipt"] = "storage/". $this->uploadFile($data["transaction_receipt"]);
+            }
             return $this->financeIncomeRepository->update($id, $data) === true ? $financeIncome->fresh() : false;
         } catch (\Exception $e) {
             throw new HttpException(500, $e->getMessage());
@@ -56,15 +55,14 @@ class FinanceIncomeService
     }
 
     public function deleteFinanceIncome(string $id) {
-        $financeIncome = $this->getFinanceIncomeById($id);
-
         try {
+            $financeIncome = $this->getFinanceIncomeById($id);
             $receiptPath = str_replace("storage/", "", $financeIncome->transaction_receipt);
 
             if(!empty($financeIncome->transaction_receipt) && Storage::disk('public')->exists(path: $receiptPath)) {
                 Storage::disk('public')->delete($receiptPath);
             }
-            
+
             return $this->financeIncomeRepository->delete($id) === true ? $financeIncome : false;
         } catch (\Exception $e) {
             throw new HttpException(500, $e->getMessage());


### PR DESCRIPTION
Ensures proper file handling during income updates and deletions by retrieving the income record within the try-catch block. This prevents potential errors if the record retrieval fails, ensuring that the file deletion logic is only executed when the record exists.