### PR TITLE
refactor: changes News Category API resource

### DIFF
--- a/app/Http/Controllers/Api/NewsCategoryController.php
+++ b/app/Http/Controllers/Api/NewsCategoryController.php
@@ -2,11 +2,12 @@
 
 namespace App\Http\Controllers\Api;
 
-use Illuminate\Http\Request;
+use App\Helpers\ApiResponse;
 use App\Http\Controllers\Controller;
-use App\Http\Requests\StoreNewsCategoryRequest;
-use App\Http\Requests\UpdateNewsCategoryRequest;
-use App\Repository\Services\NewsCategoryService;
+use App\Http\Requests\NewsCategory\StoreNewsCategoryRequest;
+use App\Http\Requests\NewsCategory\UpdateNewsCategoryRequest;
+use App\Http\Resources\NewsCategorySimpleResource;
+use App\Services\NewsCategoryService;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class NewsCategoryController extends Controller
@@ -23,12 +24,17 @@ class NewsCategoryController extends Controller
     public function index()
     {
         try {
-            return $this->newsCategoryService->getAll();
+           return ApiResponse::success([
+                "news_categories" => NewsCategorySimpleResource::collection($this->newsCategoryService->getAllNewsCategory())
+            ],
+                "Successfully fetched all news categories!",
+                200
+            );
         } catch (HttpException $e) {
-            return response()->json([
-                'success' => false,
-                'message' => $e->getMessage(),
-            ], $e->getStatusCode());
+            return ApiResponse::error(
+                "Failed to fetch news categories. Please try again.",
+                $e->getMessage(),
+                $e->getStatusCode());
         }
     }
 
@@ -38,12 +44,19 @@ class NewsCategoryController extends Controller
     public function store(StoreNewsCategoryRequest $request)
     {
         try {
-            return $this->newsCategoryService->create($request->validated());
+            return ApiResponse::success([
+                "news_category" => new NewsCategorySimpleResource(
+                    $this->newsCategoryService->createNewsCategory($request->validated())
+                    )
+            ],
+                "New news category has been created successfully!"
+            );
         } catch (HttpException $e) {
-            return response()->json([
-                'success' => false,
-                'message' => $e->getMessage(),
-            ], $e->getStatusCode());
+            return APiResponse::error(
+               "An error occurred while creating a new news category!",
+               $e->getMessage(),
+               $e->getStatusCode()
+           );
         }
     }
 
@@ -53,12 +66,18 @@ class NewsCategoryController extends Controller
     public function show(string $id)
     {
         try {
-            return $this->newsCategoryService->getById($id);
+            return ApiResponse::success([
+                "news_category" => new NewsCategorySimpleResource($this->newsCategoryService->getNewsCategoryById($id))
+            ],
+                "Successfully fetched the news category details!",
+                200
+            );
         } catch (HttpException $e) {
-            return response()->json([
-                'success' => false,
-                'message' => $e->getMessage(),
-            ], $e->getStatusCode());
+            return ApiResponse::error(
+                "The requested news category was not found!",
+                $e->getMessage(),
+                $e->getStatusCode()
+            );
         }
     }
 
@@ -68,12 +87,18 @@ class NewsCategoryController extends Controller
     public function update(UpdateNewsCategoryRequest $request, string $id)
     {
         try {
-            return $this->newsCategoryService->update($request->validated(), $id);
+            return ApiResponse::success([
+                "news_category" => new NewsCategorySimpleResource($this->newsCategoryService->updateNewsCategory($id, $request->validated()))
+            ],
+                "The news category was updated successfully!",
+                200
+            );
         } catch (HttpException $e) {
-            return response()->json([
-                'success' => false,
-                'message' => $e->getMessage(),
-            ], $e->getStatusCode());
+            return ApiResponse::error(
+                "An error occurred while updating the news category!",
+                $e->getMessage(),
+                $e->getStatusCode()
+            );
         }
     }
 
@@ -83,12 +108,18 @@ class NewsCategoryController extends Controller
     public function destroy(string $id)
     {
         try {
-            return $this->newsCategoryService->delete($id);
+            return ApiResponse::success([
+                "news_category" => new NewsCategorySimpleResource($this->newsCategoryService->deleteNewsCategory($id))
+            ],
+                "The record was successfully deleted!",
+                200
+            );
         } catch (HttpException $e) {
-            return response()->json([
-                'success' => false,
-                'message' => $e->getMessage(),
-            ], $e->getStatusCode());
+            return ApiResponse::error(
+                "An error occurred while deleting the news category!",
+                $e->getMessage(),
+                $e->getStatusCode()
+            );
         }
     }
 }

--- a/app/Http/Requests/NewsCategory/StoreNewsCategoryRequest.php
+++ b/app/Http/Requests/NewsCategory/StoreNewsCategoryRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\NewsCategory;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Contracts\Validation\Validator;

--- a/app/Http/Requests/NewsCategory/UpdateNewsCategoryRequest.php
+++ b/app/Http/Requests/NewsCategory/UpdateNewsCategoryRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\NewsCategory;
 
 use Illuminate\Validation\Rule;
 use Illuminate\Foundation\Http\FormRequest;

--- a/app/Http/Resources/NewsCategorySimpleResource.php
+++ b/app/Http/Resources/NewsCategorySimpleResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class NewsCategorySimpleResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        Carbon::setLocale("id");
+        
+        return [
+            "id" => $this->id,
+            "name" => $this->name,
+            "created_at" => Carbon::parse($this->created_at)->translatedFormat("d F Y H:i"),
+            "created_at_human" => $this->created_at->diffforhumans()
+        ];
+    }
+}

--- a/app/Models/NewsCategory.php
+++ b/app/Models/NewsCategory.php
@@ -2,17 +2,26 @@
 
 namespace App\Models;
 
+use App\Traits\AutoResourceCodeGeneration;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class NewsCategory extends Model
 {
-    use HasFactory;
+    use HasFactory, AutoResourceCodeGeneration;
 
     protected $fillable = [
         'news_category_code',
         'name'
     ];
 
-    protected $hidden = ['pivot'];
+    /**
+     * @inheritDoc
+     */
+    public function getResourceCodeConfig(): array {
+        return [
+            "column" => "news_category_code",
+            "prefix" => "NCAT"
+        ];
+    }
 }

--- a/app/Models/NewsCategoryPivot.php
+++ b/app/Models/NewsCategoryPivot.php
@@ -9,8 +9,6 @@ class NewsCategoryPivot extends Model
 {
     use HasFactory;
 
-    protected $table = 'news_category';
-
     protected $fillable = [
         'news_id',
         'news_category_id'

--- a/app/Providers/RepositoryServiceProvider.php
+++ b/app/Providers/RepositoryServiceProvider.php
@@ -2,12 +2,12 @@
 
 namespace App\Providers;
 
-use App\Models\FinanceExpense;
 use App\Repositories\Contracts\FinanceCategoryContract;
 use App\Repositories\Contracts\FinanceExpenseContract;
 use App\Repositories\Contracts\FinanceIncomeContract;
 use App\Repositories\Contracts\FinanceRecapitulationContract;
 use App\Repositories\Contracts\InfaqTypeContract;
+use App\Repositories\Contracts\NewsCategoryContract;
 use App\Repositories\Contracts\RoleContract;
 use App\Repositories\Contracts\UserContract;
 use App\Repositories\Eloquent\FinanceCategoryRepository;
@@ -16,6 +16,7 @@ use App\Repositories\Eloquent\FinanceIncomeRepository;
 use App\Repositories\Eloquent\FinanceRecapitulationRepository;
 use App\Repositories\Eloquent\UserRepository;
 use App\Repositories\Eloquent\InfaqTypeRepository;
+use App\Repositories\Eloquent\NewsCategoryRepository;
 use App\Repositories\Eloquent\RoleRepository;
 use Illuminate\Support\ServiceProvider;
 use App\Repository\Services\ItemService;
@@ -51,6 +52,7 @@ class RepositoryServiceProvider extends ServiceProvider implements DeferrablePro
         $this->app->bind(FinanceIncomeContract::class, FinanceIncomeRepository::class);
         $this->app->bind(FinanceExpenseContract::class, FinanceExpenseRepository::class);
         $this->app->bind(FinanceRecapitulationContract::class, FinanceRecapitulationRepository::class);
+        $this->app->bind(NewsCategoryContract::class, NewsCategoryRepository::class);
 
         $this->app->bind(InfaqTypeContract::class, InfaqTypeRepository::class);
         $this->app->bind(NewsCategoryInterface::class, NewsCategoryService::class);
@@ -80,6 +82,7 @@ class RepositoryServiceProvider extends ServiceProvider implements DeferrablePro
             FinanceIncomeContract::class,
             FinanceExpenseContract::class,
             FinanceRecapitulationContract::class,
+            NewsCategoryContract::class,
             InfaqTypeContract::class,
             NewsCategoryInterface::class,
             NewsInterface::class,

--- a/app/Repositories/Contracts/NewsCategoryContract.php
+++ b/app/Repositories/Contracts/NewsCategoryContract.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Repositories\Contracts;
+
+interface NewsCategoryContract
+{
+    public function all();
+    public function findOrFail(string $id);
+    public function create(array $data);
+    public function update(string $id, array $data);
+    public function delete(string $id);
+}

--- a/app/Repositories/Eloquent/NewsCategoryRepository.php
+++ b/app/Repositories/Eloquent/NewsCategoryRepository.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Repositories\Eloquent;
+use App\Models\NewsCategory;
+use App\Repositories\Contracts\NewsCategoryContract;
+
+class NewsCategoryRepository Implements NewsCategoryContract
+{
+    protected $newsCategory;
+
+    public function __construct(NewsCategory $newsCategory)
+    {
+        $this->newsCategory = $newsCategory;
+    }
+
+    // Add repository methods here
+
+    /**
+     * @inheritDoc
+     */
+    public function all() {
+        return $this->newsCategory->select("id", "news_category_code", "name", "created_at")
+        ->latest()
+        ->get();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function create(array $data) {
+        return $this->newsCategory->create($data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function delete(string $id) {
+        return $this->newsCategory->findOrFail($id)->deleteOrFail();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findOrFail(string $id) {
+        return $this->newsCategory->select("id", "news_category_code", "name", "created_at")
+        ->findOrFail($id);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function update(string $id, array $data) {
+        return $this->newsCategory->findOrFail($id)->updateOrFail($data);
+    }
+}

--- a/app/Services/NewsCategoryService.php
+++ b/app/Services/NewsCategoryService.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services;
+
+use App\Repositories\Contracts\NewsCategoryContract;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class NewsCategoryService
+{
+    public function __construct(protected NewsCategoryContract $newsCategoryRepository)
+    {
+        $this->newsCategoryRepository = $newsCategoryRepository;
+    }
+
+    public function getAllNewsCategory() {
+        return $this->newsCategoryRepository->all();
+    }
+
+    public function getNewsCategoryById(string $id) {
+        try {
+            $newsCategory = $this->newsCategoryRepository->findOrFail($id);
+        } catch (\Exception $e) {
+            throw new HttpException(404, $e->getMessage());
+        }
+
+        return $newsCategory;
+    }
+
+    public function createNewsCategory(array $data) {
+        return $this->newsCategoryRepository->create($data);
+    }
+
+    public function updateNewsCategory(string $id, array $data) {
+        $newsCategory = $this->getNewsCategoryById($id);
+
+        try {
+            return $this->newsCategoryRepository->update($id, $data) === true ? $newsCategory->fresh() : false;
+        } catch (\Exception $e) {
+            throw new HttpException(500, $e->getMessage());
+        }
+    }
+
+    public function deleteNewsCategory(string $id) {
+        $newsCategory = $this->getNewsCategoryById($id);
+
+        try {
+            return $this->newsCategoryRepository->delete($id) === true ? $newsCategory : false;
+        } catch (\Exception $e) {
+            throw new HttpException(500, $e->getMessage());
+        }
+    }
+}

--- a/database/factories/NewsCategoryFactory.php
+++ b/database/factories/NewsCategoryFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\NewsCategory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\NewsCategory>
+ */
+class NewsCategoryFactory extends Factory
+{
+    protected $model = NewsCategory::class;
+    /**
+     * Define the model"s default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $categories = [
+            "Politik", "Hukum", "Ekonomi", "Bisnis", "Olahraga", "Teknologi",
+            "Sains", "Otomotif", "Hiburan", "Gaya Hidup", "Kesehatan",
+            "Pendidikan", "Internasional", "Daerah", "Opini", "Kuliner",
+            "Wisata", "Budaya", "Properti", "Cek Fakta"
+        ];
+        return [
+            "name" => $this->faker->randomElement($categories)
+        ];
+    }
+}

--- a/database/migrations/2025_03_13_044213_create_news_category_pivots_table.php
+++ b/database/migrations/2025_03_13_044213_create_news_category_pivots_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('news_category', function (Blueprint $table) {
+        Schema::create('news_category_pivots', function (Blueprint $table) {
             $table->id();
             $table->foreignIdFor(\App\Models\News::class);
             $table->foreignIdFor(\App\Models\NewsCategory::class);
@@ -28,6 +28,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('news_category');
+        Schema::dropIfExists('news_category_pivots');
     }
 };

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -25,6 +25,7 @@ class DatabaseSeeder extends Seeder
         $this->call(FinanceCategorySeeder::class);
         $this->call(FinanceIncomeSeeder::class);
         $this->call(FinanceExpenseSeeder::class);
+        $this->call(NewsCategorySeeder::class);
         $this->call(InfaqTypeSeeder::class);
     }
 }

--- a/database/seeders/NewsCategorySeeder.php
+++ b/database/seeders/NewsCategorySeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\NewsCategory;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class NewsCategorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        NewsCategory::factory(20)->create();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -67,6 +67,10 @@ Route::middleware('auth:api')->group(function() {
                 });
                 Route::get('/recapitulations', FinanceRecapitulationController::class);
             });
+            Route::prefix('news')->group(function() {
+                Route::apiResource('/categories', NewsCategoryController::class);
+            });
+
             Route::prefix('infaq')->group(function() {
                 Route::apiResource('/types', InfaqTypeController::class);
             });
@@ -79,7 +83,6 @@ Route::middleware('auth:api')->group(function() {
         Route::apiResource('/inventory-transactions', InventoryTransactionController::class);
         Route::apiResource('/events', EventController::class);
         Route::apiResource('/event-schedules', EventScheduleController::class);
-        Route::apiResource('/news-categories', NewsCategoryController::class);
         Route::apiResource('/news', NewsController::class);
         Route::apiResource('/facility-reservations', FacilityReservationController::class);
     });


### PR DESCRIPTION
This commit introduces the News Category API resource, including:

- API endpoints for managing news categories (index, store, show, update, destroy).
- Uses ApiResponse helper for consistent response formatting.
- Implements NewsCategorySimpleResource for data transformation.
- Uses dedicated request classes for validation (StoreNewsCategoryRequest, UpdateNewsCategoryRequest).
- Adds a trait for auto-generating resource codes.
- Binds NewsCategoryContract to NewsCategoryRepository.