### PR TITLE
refactor: ensures transaction receipt URLs are correctly generated

### DIFF
--- a/app/Http/Resources/FinanceIncomeSimpleResource.php
+++ b/app/Http/Resources/FinanceIncomeSimpleResource.php
@@ -26,7 +26,7 @@ class FinanceIncomeSimpleResource extends JsonResource
             "description" => $this->description,
             "amount" => $this->amount,
             "amount_idn_format" => "Rp. ". number_format($this->amount, 0, ',', '.'),
-            "transaction_receipt" => $this->transaction_receipt,
+            "transaction_receipt" => $this->transaction_receipt ? asset($this->transaction_receipt) : null,
             "created_at" => Carbon::parse($this->created_at)->translatedFormat("d F Y H:i"),
             "created_at_human" => $this->created_at->diffforhumans()
         ];

--- a/database/factories/FinanceIncomeFactory.php
+++ b/database/factories/FinanceIncomeFactory.php
@@ -2,11 +2,14 @@
 
 namespace Database\Factories;
 
+use Exception;
 use Illuminate\Support\Str;
-use App\Models\FinanceCategory;
 use App\Models\FinanceIncome;
+use App\Models\FinanceCategory;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Http\UploadedFile;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\FinanceIncome>
@@ -21,37 +24,36 @@ class FinanceIncomeFactory extends Factory
      */
     public function definition(): array
     {
-        $isPdf = $this->faker->boolean;
-        $directory = 'public/income-receipts';
-        Storage::makeDirectory($directory);
-
-        if ($isPdf) {
-            $fileName = Str::uuid() . '.pdf';
-            $filePath = $directory . '/' . $fileName;
-            Storage::put($filePath, $this->faker->text(200));
-        } else {
-            $fileName = Str::uuid() . '.jpg';
-            $fullImagePath = storage_path("app/{$directory}/{$fileName}");
-
-            $this->faker->image(
-                dirname($fullImagePath),
-                640,
-                480,
-                null,
-                false,
-                true,
-                $fileName
-            );
-
-            $filePath = $directory . '/' . $fileName;
-        }
+        $mimeType = $this->faker->randomElement(["image", "pdf"]);
 
         return [
             "date" => $this->faker->date(),
             "finance_category_id" => FinanceCategory::inRandomOrder()->where("type", "=", "income")->value("id"),
             "description" => $this->faker->sentence(10),
             "amount" => $this->faker->numberBetween(1000, 1000000),
-            "transaction_receipt" => 'storage/income-receipts/' . basename($filePath),
+            "transaction_receipt" => Storage::url($this->fillTransactionReceipt($mimeType)),
         ];
+    }
+
+    public function fillTransactionReceipt(string $mimeType = "image") {
+        if(!empty($mimeType) && in_array($mimeType, ["image", "pdf"])) {
+            switch($mimeType) {
+                case "image":
+                    $filename = "income-receipts/img/" . Str::uuid() . ".jpg";
+
+                    $imageContent = Http::get("https://picsum.photos/640/480")->body();
+                    Storage::disk("public")->put($filename, $imageContent);
+
+                    return $filename;
+                case "pdf":
+                    $fileName = "income-receipts/pdf/" . Str::uuid() . ".pdf";
+
+                    Storage::disk("public")->put($fileName, $this->faker->sentence());
+
+                    return $fileName;
+            }
+        }
+
+        throw new Exception("An error occured while generating transaction receipt! Please ensure your mimetype is neither empty nor invalid mimetype");
     }
 }


### PR DESCRIPTION
Updates the FinanceIncomeSimpleResource to generate full URLs for transaction receipts using the asset helper.

Refactors the FinanceIncomeFactory to generate more realistic and diverse transaction receipts, handling both image and PDF file types. This enhances the quality and reliability of the generated data for testing and development.