### PR TITLE
refactor: fix news category validation on wrong table name and add ne…

### DIFF
--- a/app/Http/Requests/NewsCategory/StoreNewsCategoryRequest.php
+++ b/app/Http/Requests/NewsCategory/StoreNewsCategoryRequest.php
@@ -24,7 +24,7 @@ class StoreNewsCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ["required", "string", "unique:news,name", "max:255"]
+            'name' => ["required", "string", "unique:news_categories,name", "max:255"]
         ];
     }
 

--- a/app/Http/Resources/NewsCategorySimpleResource.php
+++ b/app/Http/Resources/NewsCategorySimpleResource.php
@@ -19,6 +19,7 @@ class NewsCategorySimpleResource extends JsonResource
 
         return [
             "id" => $this->id,
+            "news_category_code" => $this->news_category_code,
             "name" => $this->name,
             "name_upper" => ucwords($this->name),
             "slug" => $this->slug,


### PR DESCRIPTION
…ws category code on resource

Updates the unique validation rule for news category names to correctly reference the `news_categories` table.

Adds the `news_category_code` attribute to the `NewsCategorySimpleResource` to include this data in API responses.