### PR TITLE
feat: expose published news to public API

### DIFF
--- a/app/Http/Controllers/Api/NewsController.php
+++ b/app/Http/Controllers/Api/NewsController.php
@@ -26,7 +26,7 @@ class NewsController extends Controller
     {
         try {
             if($request->filled("status")) {
-                $status = $request->query("status");
+                $status = $request->input("status");
 
                 if(in_array($status, ["drafted", "published", "archived"])) {
                     return ApiResponse::success([
@@ -147,6 +147,23 @@ class NewsController extends Controller
         } catch (HttpException $e) {
             return ApiResponse::error(
                 "An error occurred while publishing the news!",
+                $e->getMessage(),
+                $e->getStatusCode()
+            );
+        }
+    }
+
+    public function expose() {
+        try {
+            return ApiResponse::success([
+                "news" => NewsSimpleResource::collection($this->newsService->exposeAllNews())
+            ],
+                "Successfully fetched all published news!",
+                200
+            );
+        } catch (HttpException $e) {
+            return ApiResponse::error(
+                "Failed to fetch published news. Please try again.",
                 $e->getMessage(),
                 $e->getStatusCode()
             );

--- a/app/Http/Resources/NewsSimpleResource.php
+++ b/app/Http/Resources/NewsSimpleResource.php
@@ -32,7 +32,7 @@ class NewsSimpleResource extends JsonResource
             "archived_at" => $this->archived_at ? Carbon::parse($this->archived_at)->translatedFormat("d F Y H:i") : null,
             "archived_at_human" => $this->archived_at?->diffforhumans(),
             "created_at" => Carbon::parse($this->created_at)->translatedFormat("d F Y H:i"),
-            "created_at_human" => $this->created_at->diffforhumans(),
+            "created_at_human" => $this->created_at?->diffforhumans(),
             "author" => new UserSimpleResource($this->user)
         ];
     }

--- a/app/Repositories/Contracts/NewsContract.php
+++ b/app/Repositories/Contracts/NewsContract.php
@@ -10,4 +10,5 @@ interface NewsContract
     public function create(array $data);
     public function update(string $id, array $data);
     public function delete(string $id);
+    public function expose();
 }

--- a/app/Repositories/Eloquent/NewsRepository.php
+++ b/app/Repositories/Eloquent/NewsRepository.php
@@ -71,4 +71,18 @@ class NewsRepository Implements NewsContract
     public function update(string $id, array $data) {
         return $this->news->findOrFail($id)->updateOrFail($data);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function expose() {
+        return $this->news->select(
+            "id", "news_code", "title", "slug",
+            "thumbnail", "content", "excerpt", "user_id",
+            "published_at"
+        )->with(["user", "newsCategory"])
+        ->where("status", "=", "published")
+        ->whereNull("archived_at")
+        ->latest()->get();
+    }
 }

--- a/app/Services/NewsService.php
+++ b/app/Services/NewsService.php
@@ -20,6 +20,10 @@ class NewsService
         return $this->newsRepository->all();
     }
 
+    public function exposeAllNews() {
+        return $this->newsRepository->expose();
+    }
+
     public function getNewsByParam(string $param) {
         return $this->newsRepository->whereEquals("status", $param);
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -55,6 +55,8 @@ Route::post('/forgot-password', ForgotPasswordController::class)
 Route::post('/reset-password', [ResetPasswordController::class, 'reset'])
 ->name('api.reset_password');
 
+Route::get('/news/published', [NewsController::class, 'expose'])->name('news.public');
+
 Route::middleware(['auth:api', 'role:administrator'])->name('api.')->group(function() {
     Route::apiResource('/roles', RoleController::class)->names('roles');
     Route::apiResource('/users', UserController::class)->names('users');
@@ -68,8 +70,7 @@ Route::middleware(['auth:api', 'role:administrator'])->name('api.')->group(funct
         Route::get('/recapitulations', FinanceRecapitulationController::class)
         ->name('recapitulations.index');
     });
-    Route::apiResource('/news-categories', NewsCategoryController::class)
-    ->names('news_categories');
+    Route::apiResource('/news-categories', NewsCategoryController::class)->names('news_categories');
     Route::apiResource('/news', NewsController::class)->names('news');
     Route::post('/news/{id}/publish', [NewsController::class, 'publish'])->name('news.publish');
     Route::post('/news/{id}/archive', [NewsController::class, 'archive'])->name('news.archive');


### PR DESCRIPTION
Adds an endpoint to retrieve all published news articles, enhancing accessibility for public consumption.

Also, fixes a potential null reference exception when accessing the creation timestamp in the NewsSimpleResource.