### PR TITLE
refactor: implement facility management with service layer

### DIFF
--- a/app/Http/Requests/Facility/StoreFacilityRequest.php
+++ b/app/Http/Requests/Facility/StoreFacilityRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Facility;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreFacilityRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            "name" => ["required", "string", "unique:facilities,name"],
+            "description" => ["required"],
+            "capacity" => ["required", "numeric", "min:0"],
+            "price_per_hour" => ["required", "numeric", "min:0"],
+            "status" => ["required", "in:available,maintenance,unavailable"],
+            "cover_image" => ["nullable", "image", "mimes:jpg,png,jpeg,webp", "max:2048"],
+            "facility_previews.*" => ["nullable", "image", "mimes:jpg,png,jpeg,webp", "max:2048"]
+        ];
+    }
+}

--- a/app/Http/Requests/Facility/UpdateFacilityRequest.php
+++ b/app/Http/Requests/Facility/UpdateFacilityRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use Illuminate\Validation\Rule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateFacilityRequest extends FormRequest
@@ -11,7 +12,7 @@ class UpdateFacilityRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -22,10 +23,15 @@ class UpdateFacilityRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => 'required|string|max:255|unique:facilities,name,' . $this->route('id'),
-            'description' => 'nullable|string',
-            'capacity' => 'required|integer|min:1',
-            'status' => 'required|in:available,unavailable',
+            "name" => ["required", "string",  Rule::unique("facilities", "name")->ignore(request()->route("facility"))],
+            "description" => ["required"],
+            "capacity" => ["required", "numeric", "min:0"],
+            "price_per_hour" => ["required", "numeric", "min:0"],
+            "status" => ["required", "in:available,maintenance,unavailable"],
+            "cover_image" => ["nullable", "image", "mimes:jpg,png,jpeg,webp", "max:2048"],
+            "facility_previews.*" => ["nullable", "image", "mimes:jpg,png,jpeg,webp", "max:2048"],
+            "remove_facility_preview_id" => ["nullable", "array"],
+            "remove_facility_preview_id.*" => ["exists:facility_previews,id"]
         ];
     }
     public function messages()

--- a/app/Http/Resources/FacilityPreviewSimpleResource.php
+++ b/app/Http/Resources/FacilityPreviewSimpleResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class FacilityPreviewSimpleResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            "facility_id" => $this->facility_id,
+            "image_path" => asset($this->image_path)
+        ];
+    }
+}

--- a/app/Http/Resources/FacilitySimpleResource.php
+++ b/app/Http/Resources/FacilitySimpleResource.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class FacilitySimpleResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        Carbon::setLocale("id");
+
+        return [
+            "id" => $this->id,
+            "name" => $this->name,
+            "name_upper" => ucwords($this->name),
+            "description" => $this->description,
+            "capacity" => $this->capacity,
+            "price_per_hour" => "Rp. ". number_format($this->price_per_hour, 0, ',', '.'),
+            "status" => $this->status,
+            "cover_image" => asset($this->cover_image),
+            "image_previews" => FacilityPreviewSimpleResource::collection($this->facilityPreview),
+            "created_at" => Carbon::parse($this->created_at)->translatedFormat("d F Y H:i"),
+            "created_at_human" => $this->created_at->diffforhumans()
+        ];
+    }
+}

--- a/app/Models/Facility.php
+++ b/app/Models/Facility.php
@@ -2,21 +2,30 @@
 
 namespace App\Models;
 
-use Illuminate\Support\Str;
+use App\Traits\AutoResourceCodeGeneration;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Facility extends Model
 {
-    use HasFactory;
-    protected $fillable = ['facility_code', 'name', 'description', 'capacity', 'status'];
+    use HasFactory, AutoResourceCodeGeneration;
+    protected $fillable = [
+        "facility_code", "name", "description", "capacity",
+        "status", "price_per_hour", "status", "cover_image"
+    ];
 
-    protected static function boot()
-    {
-        parent::boot();
-        static::creating(function ($facility) {
-            $facility->facility_code = (string) Str::uuid();
-        });
+    public function facilityPreview() {
+        return $this->hasMany(FacilityPreview::class);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getResourceCodeConfig(): array {
+        return [
+            "column" => "facility_code",
+            "prefix" => "FCTY"
+        ];
     }
 }
 

--- a/app/Models/FacilityPreview.php
+++ b/app/Models/FacilityPreview.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class FacilityPreview extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['facility_id', 'image_path'];
+
+    public function facility() {
+        return $this->belongsTo(Facility::class);
+    }
+}

--- a/app/Providers/RepositoryServiceProvider.php
+++ b/app/Providers/RepositoryServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Repositories\Contracts\FacilityContract;
 use App\Repositories\Contracts\FinanceCategoryContract;
 use App\Repositories\Contracts\FinanceExpenseContract;
 use App\Repositories\Contracts\FinanceIncomeContract;
@@ -11,6 +12,7 @@ use App\Repositories\Contracts\NewsCategoryContract;
 use App\Repositories\Contracts\NewsContract;
 use App\Repositories\Contracts\RoleContract;
 use App\Repositories\Contracts\UserContract;
+use App\Repositories\Eloquent\FacilityRepository;
 use App\Repositories\Eloquent\FinanceCategoryRepository;
 use App\Repositories\Eloquent\FinanceExpenseRepository;
 use App\Repositories\Eloquent\FinanceIncomeRepository;
@@ -56,6 +58,7 @@ class RepositoryServiceProvider extends ServiceProvider implements DeferrablePro
         $this->app->bind(FinanceRecapitulationContract::class, FinanceRecapitulationRepository::class);
         $this->app->bind(NewsCategoryContract::class, NewsCategoryRepository::class);
         $this->app->bind(NewsContract::class, NewsRepository::class);
+        $this->app->bind(FacilityContract::class, FacilityRepository::class);
 
         $this->app->bind(InfaqTypeContract::class, InfaqTypeRepository::class);
         $this->app->bind(NewsCategoryInterface::class, NewsCategoryService::class);
@@ -87,6 +90,7 @@ class RepositoryServiceProvider extends ServiceProvider implements DeferrablePro
             FinanceRecapitulationContract::class,
             NewsCategoryContract::class,
             NewsContract::class,
+            FacilityContract::class,
             InfaqTypeContract::class,
             NewsCategoryInterface::class,
             NewsInterface::class,

--- a/app/Repositories/Contracts/FacilityContract.php
+++ b/app/Repositories/Contracts/FacilityContract.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Repositories\Contracts;
+
+interface FacilityContract
+{
+    public function all();
+    public function findOrFail(string $id);
+    public function create(array $data);
+    public function update(string $id, array $data);
+    public function delete(string $id);
+}

--- a/app/Repositories/Eloquent/FacilityRepository.php
+++ b/app/Repositories/Eloquent/FacilityRepository.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Repositories\Eloquent;
+use App\Models\Facility;
+use App\Repositories\Contracts\FacilityContract;
+
+class FacilityRepository Implements FacilityContract
+{
+    protected $facility;
+
+    public function __construct(Facility $facility)
+    {
+        $this->facility = $facility;
+    }
+
+    // Add repository methods here
+
+    /**
+     * @inheritDoc
+     */
+    public function all() {
+        return $this->facility->select(
+            "id", "facility_code", "name", "description", "capacity",
+            "status", "price_per_hour", "status", "cover_image", "created_at"
+        )->with('facilityPreview')
+        ->latest()->get();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function create(array $data) {
+        return $this->facility->create($data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function delete(string $id) {
+        return $this->facility->findOrFail($id)->deleteOrFail();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findOrFail(string $id) {
+        return $this->facility->select(
+            "id", "facility_code", "name", "description", "capacity",
+            "status", "price_per_hour", "status", "cover_image", "created_at"
+        )->with('facilityPreview')
+        ->findOrFail($id);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function update(string $id, array $data) {
+        return $this->facility->findOrFail($id)->updateOrFail($data);
+    }
+}

--- a/app/Services/FacilityService.php
+++ b/app/Services/FacilityService.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\FacilityPreview;
+use Illuminate\Support\Facades\Storage;
+use App\Repositories\Contracts\FacilityContract;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class FacilityService
+{
+    public function __construct(protected FacilityContract $facilityRepository)
+    {
+        $this->facilityRepository = $facilityRepository;
+    }
+
+    public function getAllFacilities() {
+        return $this->facilityRepository->all();
+    }
+
+    public function getFacilityById(string $id) {
+        return $this->facilityRepository->findOrFail($id);
+    }
+
+    public function createFacility(array $data) {
+        if(isset($data["cover_image"]) && $data["cover_image"] instanceof \Illuminate\Http\UploadedFile) {
+            $data["cover_image"] = "storage/". $this->uploadCoverImage($data["cover_image"]);
+        }
+
+        $facility = $this->facilityRepository->create($data);
+
+        if(isset($data["facility_previews"]) && !empty($data["facility_previews"])) {
+            foreach ($data["facility_previews"] as $facilityPreview) {
+                $path = $facilityPreview->storePubliclyAs("facility-previews", "public");
+                $facility->facilityPreview()->create(["image_path" => basename($path)]);
+            }
+        }
+
+        return $facility;
+    }
+
+    public function updateFacility(string $id, array $data) {
+        try {
+            $facility = $this->getFacilityById($id);
+
+            if(isset($data["cover_image"]) && $data["cover_image"] instanceof \Illuminate\Http\UploadedFile) {
+                $coverImagePath = str_replace("storage/", "", $facility->cover_image);
+
+                if(!empty($facility->cover_image) && Storage::disk('public')->exists(path: $coverImagePath)) {
+                    Storage::disk('public')->delete($coverImagePath);
+                }
+
+                $data["cover_image"] = "storage/". $this->uploadCoverImage($data["cover_image"]);
+            }
+
+            if(isset($data["facility_previews"]) && !empty($data["facility_previews"])) {
+                foreach ($data["facility_previews"] as $facilityPreview) {
+                    $path = $facilityPreview->storePubliclyAs("facility-previews", "public");
+                    $facility->facilityPreview()->create(["image_path" => basename($path)]);
+                }
+            }
+
+            if(isset($data["remove_facility_preview_id"]) && !empty($data["remove_facility_preview_id"])) {
+                $facilityPreviews = FacilityPreview::whereIn("id", $data["remove_facility_preview_id"])->get();
+
+                foreach($facilityPreviews as $facilityPreview) {
+                    Storage::disk("public")->delete("facility-previews" . $facilityPreview->image_path);
+                    $facilityPreview->delete();
+                }
+            }
+
+            return $this->facilityRepository->update($id, $data) === true ? $facility->fresh() : false;
+        } catch (\Exception $e) {
+            throw new HttpException(500, $e->getMessage());
+        }
+    }
+
+    public function deleteFacility(string $id) {
+        try {
+            $facility = $this->getFacilityById($id);
+            $coverImagePath = str_replace("storage/", "", $facility->cover_image);
+
+            if(!empty($facility->cover_image) && Storage::disk("public")->exists($coverImagePath)) {
+                Storage::disk("public")->delete($coverImagePath);
+            }
+
+            foreach ($facility->facilityPreview as $facilityPreview) {
+                if (Storage::disk('public')->exists('facilities/' . $facilityPreview->image_path)) {
+                    Storage::disk('public')->delete('facilities/' . $facilityPreview->image_path);
+                }
+            }
+
+            return $this->facilityRepository->delete($id) === true ? $facility : false;
+        } catch (\Exception $e) {
+            throw new HttpException(500, $e->getMessage());
+        }
+    }
+
+    private function uploadCoverImage($coverImage) {
+        $fileName = $coverImage->hashName();
+
+        return $coverImage->storePubliclyAs("facility-previews", $fileName, "public");
+    }
+}

--- a/database/factories/FacilityFactory.php
+++ b/database/factories/FacilityFactory.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Facility;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Facility>
+ */
+class FacilityFactory extends Factory
+{
+    protected $model = Facility::class;
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $facilities = [
+            "Aula Serbaguna",
+            "Ruang Pertemuan",
+            "Lapangan Parkir",
+            "Ruang Belajar",
+            "Ruang Multimedia",
+            "Ruang Konsultasi",
+            "Ruang Tamu Masjid",
+            "Ruang Sekretariat",
+            "Ruang Penyimpanan",
+            "Teras Masjid",
+            "Ruang Ibadah Utama",
+            "Tempat Wudhu Pria",
+            "Tempat Wudhu Wanita",
+            "Ruang Imam",
+            "Kamar Mandi Pria",
+            "Kamar Mandi Wanita",
+            "Area Bermain Anak",
+            "Perpustakaan Masjid",
+            "Dapur Umum",
+            "Gudang Inventaris"
+        ];
+
+        return [
+            "name" => $this->faker->unique()->randomElement($facilities),
+            "description" => $this->faker->sentence(10),
+            "capacity" => $this->faker->numberBetween(10, 200),
+            "price_per_hour" => $this->faker->numberBetween(50000, 300000),
+            "status" => $this->faker->randomElement(["available", "maintenance", "unavailable"]),
+            "cover_image" => Storage::url($this->fillCoverImage())
+        ];
+    }
+
+    private function fillCoverImage() {
+        $filename = 'facility-covers/' . Str::uuid() . '.jpg';
+
+        $imageContent = Http::get('https://picsum.photos/640/480')->body();
+        Storage::disk('public')->put($filename, $imageContent);
+
+        return $filename;
+    }
+
+    public function configure():static {
+        return $this->afterCreating(function(Facility $facility) {
+            for ($i = 1; $i <= rand(3, 5); $i++) {
+                $fileName = "facility-previews/". Str::uuid() . ".jpg";
+                $imageContent = Http::get('https://picsum.photos/640/480')->body();
+
+                Storage::disk('public')->put($fileName, $imageContent);
+
+                $facility->facilityPreview()->create([
+                    'image_path' => Storage::url($fileName),
+                ]);
+            }
+        });
+    }
+}

--- a/database/migrations/2025_03_13_052922_create_facilities_table.php
+++ b/database/migrations/2025_03_13_052922_create_facilities_table.php
@@ -14,10 +14,12 @@ return new class extends Migration
         Schema::create('facilities', function (Blueprint $table) {
             $table->id();
             $table->string('facility_code', 36)->unique();
-            $table->string('name');
-            $table->text('description');
-            $table->integer('capacity');
-            $table->enum('status', ['available', 'unavailable'])->default('available');
+            $table->string('name')->nullable(false);
+            $table->text('description')->nullable(false);
+            $table->integer('capacity')->nullable(false)->default(0);
+            $table->integer('price_per_hour')->nullable(false)->default(0);
+            $table->enum('status', ['available', 'maintenance', 'unavailable'])->default('available');
+            $table->string('cover_image')->nullable(true);
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_06_11_223337_create_facility_previews_table.php
+++ b/database/migrations/2025_06_11_223337_create_facility_previews_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\Facility;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('facility_previews', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(Facility::class);
+            $table->string('image_path');
+            $table->timestamps();
+
+            $table->foreign('facility_id')->references('id')->on('facilities')
+            ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('facility_previews');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -27,6 +27,7 @@ class DatabaseSeeder extends Seeder
         $this->call(FinanceExpenseSeeder::class);
         $this->call(NewsCategorySeeder::class);
         $this->call(NewsSeeder::class);
+        $this->call(FacilitySeeder::class);
         $this->call(InfaqTypeSeeder::class);
     }
 }

--- a/database/seeders/FacilitySeeder.php
+++ b/database/seeders/FacilitySeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Facility;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class FacilitySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Facility::factory(20)->create();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -56,6 +56,7 @@ Route::post('/reset-password', [ResetPasswordController::class, 'reset'])
 ->name('api.reset_password');
 
 Route::get('/news/published', [NewsController::class, 'expose'])->name('news.public');
+Route::get('/facilities', [FacilityController::class, 'index'])->name('facilities.index');
 
 Route::middleware(['auth:api', 'role:administrator'])->name('api.')->group(function() {
     Route::apiResource('/roles', RoleController::class)->names('roles');
@@ -74,14 +75,16 @@ Route::middleware(['auth:api', 'role:administrator'])->name('api.')->group(funct
     Route::apiResource('/news', NewsController::class)->names('news');
     Route::post('/news/{id}/publish', [NewsController::class, 'publish'])->name('news.publish');
     Route::post('/news/{id}/archive', [NewsController::class, 'archive'])->name('news.archive');
+    Route::apiResource('/facilities', FacilityController::class)
+    ->except('index')
+    ->names('facilities');
 });
 
 Route::prefix('unimportant')->group(function() {
     Route::apiResource('/events', EventController::class);
     Route::apiResource('/event-schedules', EventScheduleController::class);
-    Route::apiResource('/infaq-types', InfaqTypeController::class);
-    Route::apiResource('/facilities', FacilityController::class);
     Route::apiResource('/facility-reservations', FacilityReservationController::class);
+    Route::apiResource('/infaq-types', InfaqTypeController::class);
     Route::apiResource('/items', ItemController::class);
     Route::apiResource('/income-infaq-transactions', IncomeInfaqTransactionController::class);
     Route::apiResource('/expense-transactions', ExpenseTransactionController::class);


### PR DESCRIPTION
This commit introduces a service layer for facility management, enhancing code organization and maintainability.

It implements a FacilityService to handle business logic related to facility operations, such as creation, retrieval, update, and deletion.

The controller now utilizes the FacilityService to perform these operations, improving separation of concerns and making the code more testable.

Also, it integrates API responses to standardize the format of API responses, providing a consistent structure for success and error scenarios.

The code also introduces a `FacilitySimpleResource` for formatting facility data.

It removes the `UpdateFacilityRequest` and moves the validation rules to `StoreFacilityRequest`, creating `StoreFacilityRequest` to validate facility store requests.