### PR TITLE
refactor: add handles validation errors with API response

### DIFF
--- a/app/Http/Controllers/Api/FacilityController.php
+++ b/app/Http/Controllers/Api/FacilityController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Models\Facility;
 use App\Helpers\ApiResponse;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\UpdateFacilityRequest;
@@ -56,8 +55,8 @@ class FacilityController extends Controller
 
     public function show($id)
     {
-try {
-        return ApiResponse::success([
+        try {
+            return ApiResponse::success([
                 "facility" => new FacilitySimpleResource($this->facilityService->getFacilityById($id))
             ],
                 "Successfully fetched the facility details!",

--- a/app/Http/Requests/Facility/StoreFacilityRequest.php
+++ b/app/Http/Requests/Facility/StoreFacilityRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests\Facility;
 
+use App\Helpers\ApiResponse;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
 
 class StoreFacilityRequest extends FormRequest
 {
@@ -30,5 +32,10 @@ class StoreFacilityRequest extends FormRequest
             "cover_image" => ["nullable", "image", "mimes:jpg,png,jpeg,webp", "max:2048"],
             "facility_previews.*" => ["nullable", "image", "mimes:jpg,png,jpeg,webp", "max:2048"]
         ];
+    }
+
+    protected function failedValidation(Validator $validator)
+    {
+        return ApiResponse::errorValidation($validator->errors());
     }
 }

--- a/app/Http/Requests/Facility/UpdateFacilityRequest.php
+++ b/app/Http/Requests/Facility/UpdateFacilityRequest.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Requests;
 
+use App\Helpers\ApiResponse;
 use Illuminate\Validation\Rule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
 
 class UpdateFacilityRequest extends FormRequest
 {
@@ -34,15 +36,9 @@ class UpdateFacilityRequest extends FormRequest
             "remove_facility_preview_id.*" => ["exists:facility_previews,id"]
         ];
     }
-    public function messages()
+
+    protected function failedValidation(Validator $validator)
     {
-        return [
-            'name.required' => 'Nama fasilitas harus diisi.',
-            'name.unique' => 'Nama fasilitas sudah digunakan.',
-            'capacity.required' => 'Kapasitas harus diisi.',
-            'capacity.integer' => 'Kapasitas harus berupa angka.',
-            'status.required' => 'Status harus diisi.',
-            'status.in' => 'Status harus "available" atau "unavailable".',
-        ];
+        return ApiResponse::errorValidation($validator->errors());
     }
 }


### PR DESCRIPTION
Implements a centralized way to handle validation errors in facility requests by returning a formatted API response.

This change ensures that validation failures in `StoreFacilityRequest` and `UpdateFacilityRequest` are consistently formatted using the `ApiResponse::errorValidation` method, providing a better user experience. It removes the need for custom message arrays in the `UpdateFacilityRequest`.