### PR TITLE
refactor: remove not equal role filter parameter

### DIFF
--- a/app/Filters/RoleFilter.php
+++ b/app/Filters/RoleFilter.php
@@ -5,12 +5,11 @@ use App\Filters\ApiFilter;
 
 class RoleFilter extends ApiFilter {
     protected $safeParams = [
-        "name" => ["eq", "neq", "lk"]
+        "name" => ["eq", "lk"]
     ];
 
     protected $operatorMap = [
         "eq" => "=",
-        "neq" => "!=",
         "lk" => "like"
     ];
 }


### PR DESCRIPTION
Removes the "neq" (not equal) operator from the safe parameters for the name filter, as it's not required and simplifies the filtering logic.