### PR TITLE
refactor: makes thumbnail upload optional during update

### DIFF
--- a/app/Http/Requests/News/UpdateNewsRequest.php
+++ b/app/Http/Requests/News/UpdateNewsRequest.php
@@ -30,7 +30,7 @@ class UpdateNewsRequest extends FormRequest
             "category_id" => ["required", "array"],
             "category_id.*" => ["exists:news_categories,id"],
             "status" => ["required", "in:drafted,published,archived"],
-            "thumbnail" => ["required", "image", "mimes:jpeg,png,jpg,gif", "max:2048"],
+            "thumbnail" => ["sometimes", "required", "image", "mimes:jpeg,png,jpg,gif", "max:2048"],
         ];
     }
 


### PR DESCRIPTION
Updates the validation rules for the thumbnail field in the UpdateNewsRequest to allow updates without requiring a new thumbnail. It uses the `sometimes` rule to conditionally require the thumbnail only when it is present in the request.