### PR TITLE
refactor: adds id to FacilityPreviewSimpleResource

### DIFF
--- a/app/Http/Resources/FacilityPreviewSimpleResource.php
+++ b/app/Http/Resources/FacilityPreviewSimpleResource.php
@@ -15,6 +15,7 @@ class FacilityPreviewSimpleResource extends JsonResource
     public function toArray(Request $request): array
     {
         return [
+            "id" => $this->id,
             "facility_id" => $this->facility_id,
             "image_path" => asset($this->image_path)
         ];


### PR DESCRIPTION
Adds the 'id' field to the FacilityPreviewSimpleResource.

This change ensures that the facility ID is included in the resource representation, which is useful for identifying the facility.