### PR TITLE
refactor: increases excerpt length

### DIFF
--- a/app/Traits/HasExcerptGeneration.php
+++ b/app/Traits/HasExcerptGeneration.php
@@ -8,13 +8,13 @@ trait HasExcerptGeneration {
     public static function bootHasExcerptGeneration() {
         static::creating(function ($model) {
             if(empty($model->excerpt) && !empty($model->content)) {
-                $model->excerpt = Str::limit(strip_tags($model->content), 150, '...');
+                $model->excerpt = Str::limit(strip_tags($model->content), 250, '...');
             }
         });
         static::updating(function ($model) {
             $originalContent = $model->getOriginal('content');
             if ($originalContent !== $model->content) {
-                $model->excerpt = Str::limit(strip_tags($model->content), 150, '...');
+                $model->excerpt = Str::limit(strip_tags($model->content), 250, '...');
             }
         });
     }


### PR DESCRIPTION
Increases the length of automatically generated excerpts from 150 to 250 characters.

This provides more context in the excerpt, improving content preview and discoverability.