### PR TITLE
style): standardize role names to lowercase

### DIFF
--- a/app/Http/Resources/RoleSimpleResource.php
+++ b/app/Http/Resources/RoleSimpleResource.php
@@ -21,6 +21,7 @@ class RoleSimpleResource extends JsonResource
             "id" => $this->id,
             "role_code" => $this->role_code,
             "name" => $this->name,
+            "name_upper" => ucwords(str_replace("-", " ", $this->name)),
             "created_at" => Carbon::parse($this->created_at)->translatedFormat("d F Y H:i"),
             "created_at_human" => $this->created_at->diffforhumans()
         ];

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -12,7 +12,7 @@ class RoleSeeder extends Seeder
      */
     public function run(): void
     {
-        $roles = ["Administrator", "Ketua Takmir", "Sekretaris", "Bendahara", "Donatur", "Jamaah Umum"];
+        $roles = ["administrator", "ketua-takmir", "sekretaris", "bendahara", "donatur", "jamaah-umum"];
 
         foreach ($roles as $role) {
             if(!Role::where('name', $role)->exists()) {


### PR DESCRIPTION
Updated role names in RoleSeeder to use lowercase and hyphenated format for consistency with existing database entries.