### PR TITLE
feat): add comments to news resource and update repository query

### DIFF
--- a/app/Http/Resources/NewsSimpleResource.php
+++ b/app/Http/Resources/NewsSimpleResource.php
@@ -33,7 +33,8 @@ class NewsSimpleResource extends JsonResource
             "archived_at_human" => $this->archived_at?->diffforhumans(),
             "created_at" => Carbon::parse($this->created_at)->translatedFormat("d F Y H:i"),
             "created_at_human" => $this->created_at?->diffforhumans(),
-            "author" => new UserSimpleResource($this->user)
+            "author" => new UserSimpleResource($this->user),
+            "comments" => CommentSimpleResource::collection($this->comment)
         ];
     }
 }

--- a/app/Repositories/Eloquent/NewsRepository.php
+++ b/app/Repositories/Eloquent/NewsRepository.php
@@ -23,7 +23,7 @@ class NewsRepository Implements NewsContract
             "thumbnail", "content", "excerpt", "status",
             "user_id", "published_at", "archived_at",
             "created_at",
-        )->with(["user", "newsCategory"]);
+        )->with(["user", "newsCategory", "comment"]);
     }
 
     /**


### PR DESCRIPTION
This change adds the comments relationship to the NewsSimpleResource, allowing the API to return associated comments for each news item. Additionally, the NewsRepository's baseQuery method has been updated to include the comments in the eager loading, improving data retrieval efficiency.