### PR TITLE
feat: add opening and closing balance calculations

### DIFF
--- a/app/Repositories/Eloquent/FinanceRecapitulationRepository.php
+++ b/app/Repositories/Eloquent/FinanceRecapitulationRepository.php
@@ -109,9 +109,19 @@ class FinanceRecapitulationRepository implements FinanceRecapitulationContract
                 $expenseTotal = $this->getFinanceExpenses(startDate: $startDate, endDate: $endDate)
                     ->sum("amount");
 
+                $incomeTotalPrevious = $this->getFinanceIncomes("date", null, $startDate)
+                ->where("date", "<", $startDate)->sum("amount");
+                $expenseTotalPrevious = $this->getFinanceExpenses("date", null, $startDate)
+                ->where("date", "<", value: $startDate)->sum("amount");
+
+                $openingBalance = $incomeTotalPrevious - $expenseTotalPrevious;
+                $closingBalance = $openingBalance + ($incomeTotal - $expenseTotal);
+
                 return (object) [
                     "total_income" => $incomeTotal,
-                    "total_expense" => $expenseTotal
+                    "total_expense" => $expenseTotal,
+                    "opening_balance" => $openingBalance,
+                    "closing_balance" => $closingBalance
                 ];
             })(),
             false => (function() use(&$filters) {
@@ -123,9 +133,19 @@ class FinanceRecapitulationRepository implements FinanceRecapitulationContract
                 $expenseTotal = $this->getFinanceExpenses($column, $startDate, $endDate)
                     ->sum("amount");
 
+                $incomeTotalPrevious = $this->getFinanceIncomes($column)->where($column, "<", $startDate)
+                ->sum("amount");
+                $expenseTotalPrevious = $this->getFinanceExpenses($column)->where($column, "<", $startDate)
+                ->sum(column: "amount");
+
+                $openingBalance = $incomeTotalPrevious - $expenseTotalPrevious;
+                $closingBalance = $openingBalance + ($incomeTotal - $expenseTotal);
+
                 return (object) [
                     "total_income" => $incomeTotal,
-                    "total_expense" => $expenseTotal
+                    "total_expense" => $expenseTotal,
+                    "opening_balance" => $openingBalance,
+                    "closing_balance" => $closingBalance
                 ];
             })(),
         };

--- a/app/Services/FinanceRecapitulationService.php
+++ b/app/Services/FinanceRecapitulationService.php
@@ -85,7 +85,9 @@ class FinanceRecapitulationService
 
         return (object) [
             "startDate" => $start->translatedFormat('d F Y'),
-            "endDate" => $end->translatedFormat('d F Y')
+            "endDate" => $end->translatedFormat('d F Y'),
+            "startDateRaw" => $start,
+            "endDateRaw" => $end
         ];
     }
 }

--- a/resources/views/pages/finance-recapitulation/export-pdf.blade.php
+++ b/resources/views/pages/finance-recapitulation/export-pdf.blade.php
@@ -22,6 +22,10 @@
             <div class="summary-title">RINGKASAN KEUANGAN</div>
             <table class="summary-table">
                 <tr>
+                    <td class="summary-label">Saldo Awal {{ \Carbon\Carbon::parse($datePeriod->startDateRaw)->locale("id")->translatedFormat("F Y") }}</td>
+                    <td class="summary-value amount amount-total">{{ "Rp. ". number_format($financeAccumulation->opening_balance, 0, ',', '.') }}</td>
+                </tr>
+                <tr>
                     <td class="summary-label">Total Pemasukan</td>
                     <td class="summary-value amount amount-debit">{{ "Rp. ". number_format($financeAccumulation->total_income, 0, ',', '.') }}</td>
                 </tr>
@@ -30,8 +34,8 @@
                     <td class="summary-value amount amount-credit">{{ "Rp. ". number_format($financeAccumulation->total_expense, 0, ',', '.') }}</td>
                 </tr>
                 <tr class="summary-total">
-                    <td class="summary-label">Total Saldo</td>
-                    <td class="summary-value amount">{{ "Rp. ". number_format(($financeAccumulation->total_income - $financeAccumulation->total_expense), 0, ',', '.') }}</td>
+                    <td class="summary-label">Saldo Akhir {{ \Carbon\Carbon::parse($datePeriod->endDateRaw)->locale("id")->translatedFormat("F Y") }}</td>
+                    <td class="summary-value amount">{{ "Rp. ". number_format($financeAccumulation->closing_balance, 0, ',', '.') }}</td>
                 </tr>
             </table>
         </div>


### PR DESCRIPTION
Implement calculations for opening and closing balances in the finance recapitulation. Update the FinanceRecapitulationExcel export to include these balances and adjust the PDF export view to display them. This enhances the financial report by providing a clear summary of the financial status over the specified period.