### PR TITLE
feat: add created_at and created_at_human fields

### DIFF
--- a/app/Http/Resources/CommentSimpleResource.php
+++ b/app/Http/Resources/CommentSimpleResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources;
 
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -18,6 +19,8 @@ class CommentSimpleResource extends JsonResource
             "id" => $this->id,
             "content" => $this->content,
             "user" => new UserSimpleResource($this->user),
+            "created_at" => Carbon::parse($this->created_at)->translatedFormat("d F Y"),
+            "created_at_human" => $this->created_at->diffforhumans(),
             "replies" => CommentSimpleResource::collection($this->reply)
         ];
     }


### PR DESCRIPTION
Include formatted creation date and human-readable time difference for comments in the CommentSimpleResource.