### PR TITLE
fix: correct password reset URL path

### DIFF
--- a/app/Notifications/ResetPasswordNotification.php
+++ b/app/Notifications/ResetPasswordNotification.php
@@ -37,7 +37,7 @@ class ResetPasswordNotification extends Notification implements ShouldQueue
      */
     public function toMail(object $notifiable): MailMessage
     {
-        $resetUrl = url(env("NEXT_URL"). "/password-reset?token=". $this->token. "&email=". $notifiable->getEmailForPasswordReset());
+        $resetUrl = url(env("NEXT_URL"). "/password/reset?token=". $this->token. "&email=". $notifiable->getEmailForPasswordReset());
 
         return (new MailMessage)
             ->subject("Reset Password Akun Anda")


### PR DESCRIPTION
Update the password reset URL in the ResetPasswordNotification class to use the correct path format. This change ensures that the reset link directs users to the intended password reset page.