### PR TITLE
feat: modify role separator to allow multiple roles in VerifyUserRole…

### DIFF
--- a/app/Http/Middleware/VerifyUserRole.php
+++ b/app/Http/Middleware/VerifyUserRole.php
@@ -15,7 +15,7 @@ class VerifyUserRole
      *
      * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
      */
-    public function handle(Request $request, Closure $next, string $role): Response
+    public function handle(Request $request, Closure $next, string ...$roles): Response
     {
         try {
             $user = auth()->user();
@@ -24,8 +24,8 @@ class VerifyUserRole
                 throw new HttpException(401, "Unauthorized");
             }
 
-            $allowedRoles = explode('|', $role);
-
+            $allowedRoles = array_map("strtolower", $roles);
+            
             if(!in_array(strtolower($user->role->name), $allowedRoles)) {
                 throw new HttpException(403, "Forbidden");
             }

--- a/routes/api.php
+++ b/routes/api.php
@@ -72,6 +72,6 @@ Route::middleware(['auth:api', 'role:administrator'])->name('api.')->group(funct
     Route::apiResource('/facilities', FacilityController::class)->except('index')->names('facilities');
 });
 
-Route::middleware(['auth:api', 'role:jamaah-umum'])->name('api.')->group(function() {
+Route::middleware(['auth:api', 'role:jamaah-umum,administrator'])->name('api.')->group(function() {
     Route::post('/news/{news}/comments', [CommentController::class, 'store'])->name('news.store');
 });


### PR DESCRIPTION
… middleware

Update the handle method to accept multiple roles as parameters. This change enhances the flexibility of the role verification process by allowing the middleware to check against an array of roles instead of a single role.